### PR TITLE
Update read in range to avoid byte order problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - rerendered avprs based on recent traits change
+- avoid byte order problems in the InGaAs array
 
 ### Changed
 - use new parent classes from upstream core

--- a/yaqd_wright/_wright_ingaas.py
+++ b/yaqd_wright/_wright_ingaas.py
@@ -79,7 +79,7 @@ class WrightInGaAs(UsesUart, Sensor):
             else:
                 break
         self._ser.flush()
-        return line[:512]
+        return line[-517:-5]
 
     def direct_serial_write(self, data):
         self._busy = True


### PR DESCRIPTION
If you take the _first_ 512 bytes, there seems to be some chance of other data occurring at the start, but always has _exactly_ 5 bytes ("ready") at the end, so this is more robust than taking the first 512 bytes