### PR TITLE
Fixing rounding error in wright_filter_wheel

### DIFF
--- a/yaqd_wright/_wright_filter_wheel.py
+++ b/yaqd_wright/_wright_filter_wheel.py
@@ -29,7 +29,7 @@ class WrightFilterWheel(IsHomeable, HasLimits, IsDiscrete, HasPosition, UsesUart
             self._microstep * (position - self._state["position"]) * self._steps_per_rotation / 360
         )
         self._serial_port.write(f"M {self._motornum} {step_position}\n".encode())
-        self._state["position"] = position
+        self._state["position"] += step_position*360/(self._steps_per_rotation*self._microstep)
 
     def direct_serial_write(self, message):
         self._busy = True

--- a/yaqd_wright/_wright_filter_wheel.py
+++ b/yaqd_wright/_wright_filter_wheel.py
@@ -29,7 +29,9 @@ class WrightFilterWheel(IsHomeable, HasLimits, IsDiscrete, HasPosition, UsesUart
             self._microstep * (position - self._state["position"]) * self._steps_per_rotation / 360
         )
         self._serial_port.write(f"M {self._motornum} {step_position}\n".encode())
-        self._state["position"] += step_position*360/(self._steps_per_rotation*self._microstep)
+        self._state["position"] += (
+            step_position * 360 / (self._steps_per_rotation * self._microstep)
+        )
 
     def direct_serial_write(self, message):
         self._busy = True

--- a/yaqd_wright/_wright_fuyu_linear.py
+++ b/yaqd_wright/_wright_fuyu_linear.py
@@ -31,7 +31,9 @@ class WrightFuyuLinear(IsHomeable, HasLimits, IsDiscrete, HasPosition, UsesUart,
             -1
         )  # NOTE the -1
         self._serial_port.write(f"M {self._motornum} {step_position}\n".encode())
-        self._state["position"] = position
+        self._state["position"] += (
+            step_position * 360 / (self._steps_per_rotation * self._microstep)
+        )
 
     def direct_serial_write(self, message):
         self._busy = True


### PR DESCRIPTION
Previous assignment of the position state to the intended position allowed for rounding error to aggregate. 

For example, say you can only move to the nearest degree, and you want to move move from 0.0 to  2.6 degrees. The closest motor position allows you to move 3 degrees. You do so, but you update your position state to read 2.6 degrees. If you now ask to move to 5.2 degrees, you attempt to move 2.6 degrees from your position state, which again rounds to 3 degrees, and you end up at 6 degrees. 
A more accurate position for our  5.2 degree request would be 5 degrees. We fix this aggregate rounding error by updating the position state after the first movement with 3 degrees, the real position as limited by the motors, instead of with the desired position of 2.6 degrees. This way the second request of moving to 5.2 degrees is only a change of 2.2 degrees, which rounds to 2 degrees, and the rounding error does not aggregate. 

We additionally must account for micro stepping. 